### PR TITLE
Pin to Python 3.10 for compatibility reasons

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -21,10 +21,10 @@ runs:
       awk -F '\/' '{ print tolower($2) }' |
       tr '_' '-'
       )
-  - name: Set up Python 3.x
+  - name: Set up Python 3.10
     uses: actions/setup-python@v2
     with:
-      python-version: "3.x"
+      python-version: "3.10"
   - name: Versions
     shell: bash
     run: |

--- a/release-gh/action.yml
+++ b/release-gh/action.yml
@@ -25,10 +25,10 @@ runs:
       awk -F '\/' '{ print tolower($2) }' |
       tr '_' '-'
       )
-  - name: Set up Python 3.x
+  - name: Set up Python 3.10
     uses: actions/setup-python@v2
     with:
-      python-version: "3.x"
+      python-version: "3.10"
   - name: Versions
     shell: bash
     run: |

--- a/release-pypi/action.yml
+++ b/release-pypi/action.yml
@@ -24,7 +24,7 @@ runs:
     if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
     uses: actions/setup-python@v2
     with:
-      python-version: '3.x'
+      python-version: '3.10'
   - name: Install dependencies
     if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
     shell: bash


### PR DESCRIPTION
the pinned version of pylint fails because
```
ImportError: cannot import name 'formatargspec' from 'inspect' (/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/inspect.py)
```