### PR TITLE
Upgrade to actions/checkout@v3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,8 @@ to attach bundles to the releases.  It takes the following arguments:
 
 * ``github-token``: A valid GitHub token with authorization scope to upload the file
   to the release
+* ``upload-url`` The upload URL where the release assets can be uploaded; should be
+  that of the release
 
 It can be invoked using:
 
@@ -54,6 +56,7 @@ It can be invoked using:
       uses: adafruit/workflows-circuitpython-libs/release-gh@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        upload-url: ${{ github.event.release.upload_url }}
 
 PyPI Release CI
 ---------------

--- a/build/action.yml
+++ b/build/action.yml
@@ -25,11 +25,11 @@ runs:
     run: |
       python3 --version
   - name: Checkout Current Repo
-    uses: actions/checkout@v1
+    uses: actions/checkout@v3
     with:
       submodules: true
   - name: Checkout tools repo
-    uses: actions/checkout@v2
+    uses: actions/checkout@v3
     with:
       repository: adafruit/actions-ci-circuitpython-libs
       path: actions-ci

--- a/release-gh/action.yml
+++ b/release-gh/action.yml
@@ -8,6 +8,9 @@ inputs:
   github-token:
     description: 'A GitHub token (required to upload to the release)'
     required: true
+  upload-url:
+    description: 'The release upload URL for the asset'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -45,13 +48,8 @@ runs:
     shell: bash
     run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
   - name: Upload Release Assets
-    # the 'official' actions version does not yet support dynamically
-    # supplying asset names to upload. @csexton's version chosen based on
-    # discussion in the issue below, as its the simplest to implement and
-    # allows for selecting files with a pattern.
-    # https://github.com/actions/upload-release-asset/issues/4
-    #uses: actiont actionss/upload-release-asset@v1.0.1
-    uses: csexton/release-asset-action@master
+    uses: shogo82148/actions-upload-release-asset@v1
     with:
-      pattern: "bundles/*"
-      github-token: ${{ inputs.github-token }}
+      asset_path: "bundles/*"
+      github_token: ${{ inputs.github-token }}
+      upload_url: ${{ inputs.upload-url }}

--- a/release-gh/action.yml
+++ b/release-gh/action.yml
@@ -32,11 +32,11 @@ runs:
     run: |
       python3 --version
   - name: Checkout Current Repo
-    uses: actions/checkout@v2
+    uses: actions/checkout@v3
     with:
       submodules: true
   - name: Checkout tools repo
-    uses: actions/checkout@v2
+    uses: actions/checkout@v3
     with:
       repository: adafruit/actions-ci-circuitpython-libs
       path: actions-ci

--- a/release-pypi/action.yml
+++ b/release-pypi/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
   - name: Check For pyproject.toml
     id: need-pypi
     shell: bash


### PR DESCRIPTION
v2 still uses Node.js 12, so this fixes the remaining deprecation warning.