### PR TITLE
Build bundles community ci

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -9,6 +9,12 @@ inputs:
     description: 'The version of Python to use in the CI'
     required: true
     default: '3.x'
+  package-prefix:
+    description: |
+      The prefix (or name) of your pacakge (if applicable) to use
+      for GitHub releases
+    required: true
+    default: ""
 runs:
   using: "composite"
   steps:

--- a/build/action.yml
+++ b/build/action.yml
@@ -71,9 +71,18 @@ runs:
         pip install .
         pytest
       fi
+  - name: Add the given package filename_prefix
+    id: package-prefix-arg
+    shell: bash
+    run: |
+      if [ "${{ inputs.package-prefix }}" == "" ]; then
+        echo prefix-arg="" >> $GITHUB_OUTPUT
+      else
+        echo prefix-arg="--package_folder_prefix ${{ inputs.package-prefix }}" >> $GITHUB_OUTPUT
+      fi
   - name: Build assets
     shell: bash
-    run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
+    run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location . ${{ steps.package-prefix-arg.outputs.prefix-arg }}
   - name: Archive bundles
     uses: actions/upload-artifact@v3
     with:


### PR DESCRIPTION
For non-Adafruit bundles, the zip files produced during pull request CI do not contain the library's py or mpy files, because there is no way to provide an alternate package-prefix; this is currently only accepted when building releases.

This PR addresses the limitation by adding the new parameter. However, in order to build correctly, the individual libs still need to use it, similar to:
```
    - name: Run Build CI workflow
      uses: adafruit/workflows-circuitpython-libs/build@build-bundles-community-ci
      with:
        package-prefix: jepler_udecimal
```
(though after this PR is merged the workflow branch name would go back to `@main`)