### PR TITLE
Allow bundles to be skipped from being built

### DIFF
--- a/release-gh/action.yml
+++ b/release-gh/action.yml
@@ -21,6 +21,13 @@ inputs:
       for GitHub releases
     required: true
     default: ""
+  ignore-bundles:
+    description: |
+      A comma and space separated list of bundles to be skipped when building.
+      Valid options are py, mpy, example, and json.  For example, to skip
+      building the MPY and example bundles, this field would be: mpy, example
+    required: true
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -63,9 +70,23 @@ runs:
       else
         echo prefix-arg="--package_folder_prefix ${{ inputs.package-prefix }}" >> $GITHUB_OUTPUT
       fi
+  - name: Add the given bundle ignores
+    id: ignore-bundles-arg
+    shell: bash
+    run: |
+      if [ "${{ inputs.ignore-bundles }}" == "" ]; then
+        echo ignore-bundles="" >> $GITHUB_OUTPUT
+      else
+        echo ignore-bundles='--ignore "${{ inputs.ignore-bundles }}"' >> $GITHUB_OUTPUT
+      fi
   - name: Build assets
     shell: bash
-    run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location . ${{ steps.package-prefix-arg.outputs.prefix-arg }}
+    run: |
+      circuitpython-build-bundles \
+      --filename_prefix ${{ steps.repo-name.outputs.repo-name }} \
+      --library_location . \
+      ${{ steps.package-prefix-arg.outputs.prefix-arg }} \
+      ${{ steps.ignore-bundles-arg.outputs.prefix-arg }}
   - name: Upload Release Assets
     uses: shogo82148/actions-upload-release-asset@v1
     with:


### PR DESCRIPTION
Allows specific bundles to be skipped when buidling bundles for releases.