### PR TITLE
Use script to announce pre-commit hook versions

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -58,6 +58,10 @@ runs:
     run: git describe --dirty --always --tags
   - name: Setup problem matchers
     uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1
+  - name: Print pre-commit hook versions
+    shell: bash
+    run: |
+      python actions-ci/print_precommit_versions.py
   - name: Pre-commit hooks
     shell: bash
     run: |


### PR DESCRIPTION
Step 2 to resolving issues like https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/pull/162#issuecomment-1625685201 is to use the script created in https://github.com/adafruit/actions-ci-circuitpython-libs/pull/20

Drafted until https://github.com/adafruit/actions-ci-circuitpython-libs/pull/20 is merged.