### PR TITLE
pin Python to 3.11

### DIFF
--- a/release-gh/action.yml
+++ b/release-gh/action.yml
@@ -14,7 +14,7 @@ inputs:
   python-version:
     description: 'The version of Python to use in the CI'
     required: true
-    default: '3.x'
+    default: '3.11'
   package-prefix:
     description: |
       The prefix (or name) of your pacakge (if applicable) to use
@@ -40,7 +40,7 @@ runs:
       awk -F '\/' '{ print tolower($2) }' |
       tr '_' '-'
       ) >> $GITHUB_OUTPUT
-  - name: Set up Python 3.x
+  - name: Set up requested Python version
     uses: actions/setup-python@v4
     with:
       python-version: ${{ inputs.python-version }}

--- a/release-pypi/action.yml
+++ b/release-pypi/action.yml
@@ -14,7 +14,7 @@ inputs:
   python-version:
     description: 'The version of Python to use in the CI'
     required: true
-    default: '3.x'
+    default: '3.11'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Fixes #31 for now. But we need to move to `venv` from `virtualenv`.