### PR TITLE
Pin missed file to Python 3.11

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -8,7 +8,7 @@ inputs:
   python-version:
     description: 'The version of Python to use in the CI'
     required: true
-    default: '3.x'
+    default: '3.11'
   package-prefix:
     description: |
       The prefix (or name) of your pacakge (if applicable) to use
@@ -27,7 +27,7 @@ runs:
       awk -F '\/' '{ print tolower($2) }' |
       tr '_' '-'
       ) >> $GITHUB_OUTPUT
-  - name: Set up Python 3.x
+  - name: Set up Python 3.11
     uses: actions/setup-python@v4
     with:
       python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
Fixes #31. #32 was missing this file, which was still causing builds to fail.