### PR TITLE
Fix using ouput of ignore-bundles-arg

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -107,7 +107,7 @@ runs:
       --filename_prefix ${{ steps.repo-name.outputs.repo-name }} \
       --library_location . \
       ${{ steps.package-prefix-arg.outputs.prefix-arg }} \
-      ${{ steps.ignore-bundles-arg.outputs.prefix-arg }}
+      ${{ steps.ignore-bundles-arg.outputs.ignore-bundles }}
   - name: Archive bundles
     uses: actions/upload-artifact@v3
     with:

--- a/release-gh/action.yml
+++ b/release-gh/action.yml
@@ -88,7 +88,7 @@ runs:
       --filename_prefix ${{ steps.repo-name.outputs.repo-name }} \
       --library_location . \
       ${{ steps.package-prefix-arg.outputs.prefix-arg }} \
-      ${{ steps.ignore-bundles-arg.outputs.prefix-arg }}
+      ${{ steps.ignore-bundles-arg.outputs.ignore-bundles }}
   - name: Upload Release Assets
     uses: shogo82148/actions-upload-release-asset@v1
     with:


### PR DESCRIPTION
Fixes an issue where the output of the `ignore-bundles-arg` step wasn't being referenced correctly