### PR TITLE
use python 3.12 in build action

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -8,7 +8,7 @@ inputs:
   python-version:
     description: 'The version of Python to use in the CI'
     required: true
-    default: '3.11'
+    default: '3.12'
   package-prefix:
     description: |
       The prefix (or name) of your package (if applicable) to use
@@ -34,7 +34,7 @@ runs:
       awk -F '\/' '{ print tolower($2) }' |
       tr '_' '-'
       ) >> $GITHUB_OUTPUT
-  - name: Set up Python 3.11
+  - name: Set up Python 3.12
     uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
This resolves an issue that I'm facing during the docs build for a new library: https://github.com/adafruit/Adafruit_CircuitPython_Argv_File/actions/runs/14862174307/job/41729654249#step:2:1072

I'm not entirely certain the root cause of the issue but it seems that something inside of python 3.11 is unappy trying to parse the line of code `return f"{file_location}.{path.absolute().replace("/", "_")}.argv"`

The line of code works fine on a CircuitPython device, I tested inside of local containers and on python 3.12 and 3.13 the docs do build successfully. They got built successfully inside of RTD as well which uses 3.13. The issue building seems to be specifically inside github build action where it uses python 3.11.